### PR TITLE
Remove forceCoversAnnotation=true from phpunit.xml.dist

### DIFF
--- a/root/phpunit.xml.dist
+++ b/root/phpunit.xml.dist
@@ -1,8 +1,7 @@
 <phpunit
  colors="true"
  bootstrap="vendor/autoload.php"
- backupGlobals="false"
- forceCoversAnnotation="true">
+ backupGlobals="false">
   <testsuites>
     <testsuite>
       <directory>tests/src</directory>


### PR DESCRIPTION
I don't think this is a good idea to require `@covers` annotations by default. At least, I don't see popular libraries that do this.

So IMO it should be disabled by default.

When the developers set up code coverage with existing tests, he does not expect to add `@covers@ annotations. But with current configuration PHPUnit Coverage shows 0%, which is incorrect indeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clippings/package-template/2)
<!-- Reviewable:end -->
